### PR TITLE
chore: bump package version to 0.2.0 in pyproject.toml and workspace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boltwood"
-version = "0.1.0"
+version = "0.2.0"
 description = "A hypermodern, type-safe, zero-dependency python library for the Boltwood II & III cloud sensors."
 authors = [{ name = "michealroberts", email = "michael@observerly.com" }]
 maintainers = [{ name = "Michael Roberts", email = "michael@observerly.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "boltwood"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "celerity" },


### PR DESCRIPTION
chore: bump package version to 0.2.0 in pyproject.toml and workspace