### PR TITLE
chore: bump package version to 0.3.0 in pyproject.toml and workspace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boltwood"
-version = "0.2.0"
+version = "0.3.0"
 description = "A hypermodern, type-safe, zero-dependency python library for the Boltwood II & III cloud sensors."
 authors = [{ name = "michealroberts", email = "michael@observerly.com" }]
 maintainers = [{ name = "Michael Roberts", email = "michael@observerly.com" }]

--- a/src/boltwood/version.py
+++ b/src/boltwood/version.py
@@ -9,6 +9,6 @@ from typing import Tuple
 
 # **************************************************************************************
 
-BOLTWOOD_DRIVER_SEMANTIC_VERSION: Tuple[int, int, int] = (0, 1, 0)
+BOLTWOOD_DRIVER_SEMANTIC_VERSION: Tuple[int, int, int] = (0, 3, 0)
 
 # **************************************************************************************

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "boltwood"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "celerity" },


### PR DESCRIPTION
chore: bump package version to 0.3.0 in pyproject.toml and workspace